### PR TITLE
feat(plugins): add spelling and grammar tools

### DIFF
--- a/nvim/.config/nvim/lua/config/options.lua
+++ b/nvim/.config/nvim/lua/config/options.lua
@@ -5,3 +5,12 @@
 vim.opt.wrap = true
 vim.g.codeium_os = "Darwin"
 vim.g.codeium_arch = "arm64"
+
+-- Keymaps for the spell checker:
+-- *   z=: Show spelling suggestions.
+-- *   ]s: Move to the next misspelled word.
+-- *   [s: Move to the previous misspelled word.
+-- *   zg: Add the word under the cursor to your dictionary.
+-- *   <leader>ss: Toggle the spell checker on and off.
+vim.opt.spell = true
+vim.opt.spelllang = { "en", "fr" }

--- a/nvim/.config/nvim/lua/plugins/spelling.lua
+++ b/nvim/.config/nvim/lua/plugins/spelling.lua
@@ -1,0 +1,38 @@
+return {
+  {
+    "mason-org/mason.nvim",
+    opts = function(_, opts)
+      vim.list_extend(opts.ensure_installed, { "typos-ls", "harper-ls" })
+    end,
+  },
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        typos_lsp = {},
+        harper_lsp = {
+          settings = {
+            ["harper-ls"] = {
+              -- harper-ls is English-only. French is handled by Neovim's built-in spell checker.
+              dialect = "American",
+              linters = {
+                SpellCheck = true,
+                SpelledNumbers = false,
+                AnA = true,
+                SentenceCapitalization = true,
+                UnclosedQuotes = true,
+                WrongQuotes = false,
+                LongSentences = true,
+                RepeatedWords = true,
+                Spaces = true,
+                Matcher = true,
+                CorrectNumberSuffix = true
+              },
+              diagnosticSeverity = "hint",
+            }
+          }
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
- Add and configure Neovim's built-in spell checker for English and French.
- Add a keymap (`<leader>ss`) to toggle spell checking.
- Install and configure `typos-lsp` for finding typos in source code.
- Install and configure `harper-ls` for English grammar and style checking.
- Consolidate the LSP configuration in `lua/plugins/spelling.lua`.