### PR TITLE
feat(nvim): integrate pi-nvim coding agent\n\n- Add `pi-nvim` Neovim …

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -179,6 +179,7 @@ brew "tfsec"                                    # Security scanner for Terraform
 brew "colima"                                   # Container runtimes with minimal setup
 brew "docker"                                   # Docker command-line client
 brew "docker-compose"                           # Define and run multi-container applications
+brew "docker-buildx"                            # Docker CLI plugin for building and pushing container images
 
 ## Graphics
 brew "asciinema"                                # Record and share terminal sessions

--- a/fish/.config/fish/conf.d/200_editor_aliases.fish
+++ b/fish/.config/fish/conf.d/200_editor_aliases.fish
@@ -1,3 +1,3 @@
 alias more 'bat -n --color=always --style=plain'
 
-alias pi 'env GOOGLE_CLOUD_PROJECT=$VERTEXAI_PROJECT_ID GOOGLE_CLOUD_LOCATION=$VERTEXAI_REGION pi'
+alias pi 'env GOOGLE_CLOUD_PROJECT=$VERTEXAI_PROJECT_ID GOOGLE_CLOUD_LOCATION=$VERTEXAI_REGION pi --session-dir $HOME/.pi/sessions'

--- a/nvim/.config/nvim/lua/plugins/README.md
+++ b/nvim/.config/nvim/lua/plugins/README.md
@@ -117,6 +117,7 @@ LazyVim-based configuration. Each file in this directory is auto-loaded by Lazy.
 | Plugin | File | Description |
 |--------|------|-------------|
 | `nickjvandyke/opencode.nvim` | `ai.lua` | OpenCode AI agent inside Neovim. `<C-a>` sends selection to it, `<C-x>` opens action picker, `<C-.>` toggles the panel. `go`/`goo` operator motions to add ranges to the session. |
+| `carderne/pi-nvim` | `ai.lua` | Bridge between pi coding agent and Neovim. Connects via unix socket to a running pi session. `<leader>p` opens the send dialog, `<leader>pp` prompt, `<leader>pf` file, `<leader>ps` selection, `<leader>pb` buffer, `<leader>pi` ping, `<leader>pS` switch session. |
 
 ---
 

--- a/nvim/.config/nvim/lua/plugins/ai.lua
+++ b/nvim/.config/nvim/lua/plugins/ai.lua
@@ -1,5 +1,19 @@
 return {
   {
+    "carderne/pi-nvim",
+    config = function()
+      require("pi-nvim").setup()
+
+      vim.keymap.set({ "n", "v" }, "<leader>p", ":Pi<CR>", { desc = "Send to pi" })
+      vim.keymap.set("n", "<leader>pp", ":PiSend<CR>", { desc = "Send prompt" })
+      vim.keymap.set("n", "<leader>pf", ":PiSendFile<CR>", { desc = "Send file" })
+      vim.keymap.set("v", "<leader>ps", ":PiSendSelection<CR>", { desc = "Send selection" })
+      vim.keymap.set("n", "<leader>pb", ":PiSendBuffer<CR>", { desc = "Send buffer" })
+      vim.keymap.set("n", "<leader>pi", ":PiPing<CR>", { desc = "Ping pi" })
+      vim.keymap.set("n", "<leader>pS", ":PiSessions<CR>", { desc = "Switch session" })
+    end,
+  },
+  {
     "nickjvandyke/opencode.nvim",
     version = "*", -- Latest stable release
     dependencies = {

--- a/nvim/.config/nvim/lua/plugins/keymaps.lua
+++ b/nvim/.config/nvim/lua/plugins/keymaps.lua
@@ -31,6 +31,7 @@ return {
         ["<leader>u"] = { name = "+ui" },
         ["<leader>w"] = { name = "+windows" },
         ["<leader>x"] = { name = "+diagnostics/quickfix" },
+        ["<leader>p"] = { name = "+pi" },
       }
 
       opts.spec = opts.spec or {}


### PR DESCRIPTION
…plugin for AI-powered coding assistance.\n- Configure keymaps (`<leader>p` prefix) for interacting with the `pi` agent.\n- Update `pi` alias in Fish to support session directories.\n- Add `docker-buildx` to Brewfile as a dependency.\n- Document new plugin and keybindings in the Neovim plugin `README.md`.